### PR TITLE
Docs: Added missing description of pytest option '--es-encrypted'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,9 @@ added by the plugin:
                             user-defined properties in the easy-server server and vault files.
                             Default: No validation.
 
+    --es-encrypted          Require that the vault file (if specified) is encrypted and error out otherwise.
+                            Default: Tolerate unencrypted vault file.
+
 
 .. _`Documentation and change log`:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Docs: Added missing description of pytest option '--es-encrypted' introduced
+  in version 0.7.0. (issue #61)
+
 **Enhancements:**
 
 * Added support for validating the user-defined extensions in the easy-server

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,9 @@ added by the plugin:
                             user-defined properties in the easy-server server and vault files.
                             Default: No validation.
 
+    --es-encrypted          Require that the vault file (if specified) is encrypted and error out otherwise.
+                            Default: Tolerate unencrypted vault file.
+
 
 .. toctree::
    :maxdepth: 2

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -271,6 +271,22 @@ defaults:
                             Default: The default from the server file.
 
 
+.. _`Requiring that the vault file is encrypted`:
+
+Requiring that the vault file is encrypted
+------------------------------------------
+
+By default, the vault file may be encrypted or unencrypted. If the vault file
+is checked into a repository, it is useful to ensure that it is encrypted,
+to avoid unintentional checkin of an unencrypted vault file. The can be
+ensured by specifying the following pytest option:
+
+.. code-block:: text
+
+    --es-encrypted          Require that the vault file (if specified) is encrypted and error out otherwise.
+                            Default: Tolerate unencrypted vault file.
+
+
 .. _`Validating user-defined extensions in server and vault files`:
 
 Validating user-defined extensions in server and vault files

--- a/pytest_easy_server/plugin.py
+++ b/pytest_easy_server/plugin.py
@@ -80,7 +80,7 @@ Default: No validation.
         default=False,
         help="""\
 Require that the vault file (if specified) is encrypted and error out otherwise.
-Default: Tolerate unencrypted vault file
+Default: Tolerate unencrypted vault file.
 """)
 
 


### PR DESCRIPTION
For details, see the commit message.